### PR TITLE
Configure strict pytest defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ addopts = [
   "--verbose",
   "-ra",  # show extra test summary info for all tests except passed tests
 ]
+filterwarnings = ["error"]
 minversion = "9.0"
+required_plugins = []
+strict = true
 testpaths = ["tests"]
 
 [tool.ruff]


### PR DESCRIPTION
Enable pytest warning-as-error handling, strict configuration, and explicit plugin settings in the template test configuration.